### PR TITLE
fix: ANTIALIAS renamed to LANCZOS in PIL

### DIFF
--- a/drawilleplot/__init__.py
+++ b/drawilleplot/__init__.py
@@ -63,7 +63,7 @@ class FigureCanvasDrawille(FigureCanvasAgg):
         ratio = tw / float(w)
         w = tw
         h = int(h * ratio)
-        i = i.resize((w, h), Image.ANTIALIAS)
+        i = i.resize((w, h), Image.LANCZOS)
 
         i = i.convert(mode="L")
 


### PR DESCRIPTION
The renaming happened in 2.7.0:
https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html#antialias-renamed-to-lanczos

It appears as though backward compatibility has been removed some time since then.